### PR TITLE
Update compose files to modern standard

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,12 +1,13 @@
-grafana:
-  ports:
-    - "3000:3000"
-  environment:
-    - GF_SECURITY_ADMIN_USER=admin
-    - GF_SECURITY_ADMIN_PASSWORD=admin
+services:
+  grafana:
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
 
-graphite:
-  ports:
-    - "8000:80"
-    - "8001:2003"
-    - "8002:2004"
+  graphite:
+    ports:
+      - "8000:80"
+      - "8001:2003"
+      - "8002:2004"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,3 +1,5 @@
+version: "3.1"
+
 services:
   grafana:
     ports:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,18 +1,19 @@
-grafana:
-  restart: always
-  volumes:
-    - /app/metrics/grafana/lib:/var/lib/grafana
-  ports:
-    - "8012:3000"
-  environment:
-    - GF_SECURITY_ADMIN_USER
-    - GF_SECURITY_ADMIN_PASSWORD
+services:
+  grafana:
+    restart: always
+    volumes:
+      - /app/metrics/grafana/lib:/var/lib/grafana
+    ports:
+      - "8012:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER
+      - GF_SECURITY_ADMIN_PASSWORD
 
-graphite:
-  ports:
-    - "8013:80"
-    - "8001:2003"
-    - "8002:2004"
-  restart: always
-  volumes:
-    - /backup/graphite/:/opt/graphite/storage
+  graphite:
+    ports:
+      - "8013:80"
+      - "8001:2003"
+      - "8002:2004"
+    restart: always
+    volumes:
+      - /backup/graphite/:/opt/graphite/storage

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,3 +1,5 @@
+version: "3.1"
+
 services:
   grafana:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3.1"
+
 services:
   grafana:
     image: grafana/grafana:6.7.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-grafana:
-  image: grafana/grafana:6.7.4
-  links:
-    - graphite
+services:
+  grafana:
+    image: grafana/grafana:6.7.4
+    depends_on:
+      - graphite
 
-graphite:
-  image: graphiteapp/graphite-statsd:1.1.7-6
+  graphite:
+    image: graphiteapp/graphite-statsd:1.1.7-6


### PR DESCRIPTION
# Update to the new [compose specification](https://compose-spec.io/)

- [x] Make sure the compose files adhere to the new [spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md).
- [x] Find out if the deprecated `link` option ([docs](https://docs.docker.com/network/links/)) is actually used for anything special that `depends_on` and docker networks can't provide. Do they share environment vars? 

